### PR TITLE
Refactored API responses to adhere to a standard

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
 
 class Handler extends ExceptionHandler
 {
@@ -52,6 +53,13 @@ class Handler extends ExceptionHandler
     {
         if ($request->route() && in_array('api', $request->route()->middleware())) {
             $request->headers->set('Accept', 'application/json');
+        }
+
+        if ($request->expectsJson()) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], $exception->getStatusCode());
         }
 
         return parent::render($request, $exception);

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -44,7 +44,8 @@ class ForgotPasswordController extends Controller
         );
 
         return new JsonResponse([
-            'message' => 'A password reset email has been sent',
+            'success' => true,
+            'message' => 'A password reset email has been sent.',
         ], 200);
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -37,7 +37,7 @@ class LoginController extends Controller
      * Create a new LoginController instance.
      *
      * @param  \App\Contracts\Services\AuthService  $authService
-     * 
+     *
      * @return void
      */
     public function __construct(AuthService $authService)
@@ -70,7 +70,8 @@ class LoginController extends Controller
             $this->fireLockoutEvent($request);
 
             return new JsonResponse([
-                'error' => 'Too many login attempts',
+                'success' => false,
+                'message' => 'Too many authentication attempts.',
             ], 400);
         }
 
@@ -78,14 +79,21 @@ class LoginController extends Controller
             $data = $this->authService->attemptLoginWithCredentials($credentials);
 
             return new JsonResponse([
-                'access_token' => $data['access_token'],
-                'token_type' => 'bearer',
-                'expires_in' => $data['expires_in'],
+                'success' => true,
+                'message' => 'Successfully authenticated.',
+                'data' => [
+                    'access_token' => $data['access_token'],
+                    'token_type' => 'bearer',
+                    'expires_in' => $data['expires_in'],
+                ],
             ], 200);
         } catch (\Exception $e) {
             $this->incrementLoginAttempts($request);
             
-            return new JsonResponse(['error' => 'Unauthorized'], 401);
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'Unauthorized.'
+            ], 401);
         }
     }
 
@@ -98,6 +106,9 @@ class LoginController extends Controller
     {
         $this->authService->logout(true);
 
-        return new JsonResponse(['message' => 'Success'], 200);
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'The user has successfully been logged out.',
+        ], 200);
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -50,13 +50,18 @@ class RegisterController extends Controller
             $data = $this->authService->attemptLoginWithCredentials($credentials);
 
             return new JsonResponse([
-                'access_token' => $data['access_token'],
-                'token_type' => 'bearer',
-                'expires_in' => $data['expires_in'],
+                'success' => true,
+                'message' => 'Successfully authenticated.',
+                'data' => [
+                    'access_token' => $data['access_token'],
+                    'token_type' => 'bearer',
+                    'expires_in' => $data['expires_in'],
+                ],
             ], 200);
         } catch (\Exception $e) {
             return new JsonResponse([
-                'error' => 'There was an error creating the account',
+                'success' => false,
+                'message' => 'There was an error creating the account.',
             ], 500);
         }
     }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -73,7 +73,8 @@ class ResetPasswordController extends Controller
     protected function sendResetResponse(): JsonResponse
     {
         return new JsonResponse([
-            'message' => 'Password has successfully reset',
+            'success' => true,
+            'message' => 'Password has successfully reset.',
         ], 200);
     }
 
@@ -85,7 +86,8 @@ class ResetPasswordController extends Controller
     protected function sendResetFailedResponse(): JsonResponse
     {
         return new JsonResponse([
-            'message' => 'There was a problem resetting the password',
+            'success' => false,
+            'message' => 'There was a problem resetting the password.',
         ], 500);
     }
 }

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -50,7 +50,8 @@ class VerificationController extends Controller
 
             if ($user->hasVerifiedEmail()) {
                 return new JsonResponse([
-                    'message' => 'Email has already been verified',
+                    'success' => true,
+                    'message' => 'Email has already been verified.',
                 ], 200);
             }
 
@@ -59,7 +60,8 @@ class VerificationController extends Controller
             }
 
             return new JsonResponse([
-                'message' => 'Email has been successfully verified',
+                'success' => true,
+                'message' => 'Email has been successfully verified.',
             ], 200);
         } catch (\Exception $e) {
             throw new AuthorizationException;
@@ -87,14 +89,16 @@ class VerificationController extends Controller
 
         if ($user->hasVerifiedEmail()) {
             return new JsonResponse([
-                'error' => 'Email has already been verified',
+                'success' => false,
+                'message' => 'Email has already been verified.',
             ], 403);
         }
 
         $user->sendEmailVerificationNotification();
 
         return new JsonResponse([
-            'message' => 'Success',
+            'success' => true,
+            'message' => 'Verification email has been sent.',
         ], 200);
     }
 }

--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -36,7 +36,11 @@ class LocationController extends Controller
      */
     public function index(): JsonResponse
     {
-        return new JsonResponse($this->locationService->all(), 200);
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'data' => $this->locationService->all(),
+        ], 200);
     }
 
     /**
@@ -48,10 +52,11 @@ class LocationController extends Controller
      */
     public function store(CreateLocationFormRequest $request): JsonResponse
     {
-        return new JsonResponse(
-            $this->locationService->create($request->validated()),
-            201
-        );
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'Successfully created the record.',
+            'data' => $this->locationService->create($request->validated()),
+        ], 201);
     }
 
     /**
@@ -63,7 +68,11 @@ class LocationController extends Controller
      */
     public function show(string $locationId): JsonResponse
     {
-        return new JsonResponse($this->locationService->findOrFail($locationId), 200);
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'data' => $this->locationService->findOrFail($locationId),
+        ], 200);
     }
 
     /**
@@ -76,13 +85,11 @@ class LocationController extends Controller
      */
     public function update(UpdateLocationFormRequest $request, string $locationId): JsonResponse
     {
-        return new JsonResponse(
-            $this->locationService->update(
-                $locationId,
-                $request->validated()
-            ),
-            200
-        );
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'Successfully updated the record.',
+            'data' => $this->locationService->update($locationId, $request->validated()),
+        ], 200);
     }
 
     /**
@@ -94,6 +101,10 @@ class LocationController extends Controller
      */
     public function destroy(string $locationId): JsonResponse
     {
-        return new JsonResponse($this->locationService->delete($locationId), 200);
+        return new JsonResponse([
+            'success' => true,
+            'message' => 'Successfully deleted the record.',
+            'data' => $this->locationService->delete($locationId),
+        ], 200);
     }
 }

--- a/tests/Feature/Routes/Auth/ForgotPasswordRoutesTest.php
+++ b/tests/Feature/Routes/Auth/ForgotPasswordRoutesTest.php
@@ -24,8 +24,13 @@ class ForgotPasswordRoutesTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'A password reset email has been sent',
+            'success' => true,
+            'message' => 'A password reset email has been sent.',
         ]);
         Notification::assertSentTo($user, ResetPassword::class);
     }
@@ -40,8 +45,13 @@ class ForgotPasswordRoutesTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'A password reset email has been sent',
+            'success' => true,
+            'message' => 'A password reset email has been sent.',
         ]);
         Notification::assertNothingSent();
     }

--- a/tests/Feature/Routes/Auth/ResetPasswordRoutesTest.php
+++ b/tests/Feature/Routes/Auth/ResetPasswordRoutesTest.php
@@ -30,8 +30,13 @@ class ResetPasswordRoutesTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'Password has successfully reset',
+            'success' => true,
+            'message' => 'Password has successfully reset.',
         ]);
         Event::assertDispatched(PasswordChanged::class);
     }
@@ -51,8 +56,13 @@ class ResetPasswordRoutesTest extends TestCase
         ]);
 
         $response->assertStatus(500);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'There was a problem resetting the password',
+            'success' => false,
+            'message' => 'There was a problem resetting the password.',
         ]);
         Event::assertNotDispatched(PasswordChanged::class);
     }

--- a/tests/Feature/Routes/Auth/VerificationRoutesTest.php
+++ b/tests/Feature/Routes/Auth/VerificationRoutesTest.php
@@ -43,8 +43,13 @@ class VerificationRoutesTest extends TestCase
         $response = $this->get($user->generateVerificationUrl());
 
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'Email has been successfully verified',
+            'success' => true,
+            'message' => 'Email has been successfully verified.',
         ]);
     }
 
@@ -58,7 +63,12 @@ class VerificationRoutesTest extends TestCase
         $response = $this->get($user->generateVerificationUrl() . 'some-extra-data');
 
         $response->assertStatus(403);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
+            'success' => false,
             'message' => 'Invalid signature.',
         ]);
     }
@@ -71,8 +81,13 @@ class VerificationRoutesTest extends TestCase
         $response = $this->get($user->generateVerificationUrl());
 
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
         $response->assertJson([
-            'message' => 'Email has already been verified',
+            'success' => true,
+            'message' => 'Email has already been verified.',
         ]);
     }
 
@@ -104,6 +119,15 @@ class VerificationRoutesTest extends TestCase
         $response = $this->post('/api/email/resend', [], [
             'Authorization' => 'Bearer ' . $token,
         ]);
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Verification email has been sent.',
+        ]);
 
         Notification::assertSentTo($user, VerifyEmail::class);
     }
@@ -121,6 +145,15 @@ class VerificationRoutesTest extends TestCase
             'Authorization' => 'Bearer ' . $token,
         ]);
 
+        $response->assertStatus(403);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
+        $response->assertJson([
+            'success' => false,
+            'message' => 'Email has already been verified.',
+        ]);
         Notification::assertNotSentTo($user, VerifyEmail::class);
     }
 
@@ -134,7 +167,12 @@ class VerificationRoutesTest extends TestCase
         $response = $this->post('/api/email/resend');
 
         $response->assertStatus(401);
-        $response->assertJsonFragment([
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
+        $response->assertJson([
+            'success' => false,
             'message' => 'Token not provided',
         ]);
     }

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -19,7 +19,16 @@ class LocationRoutesTest extends TestCase
         $response = $this->get('/api/locations');
 
         $response->assertStatus(200);
-        $response->assertJsonCount(10);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+        ]);
+        $response->assertJsonCount(10, 'data');
     }
 
     /** @test */
@@ -30,11 +39,20 @@ class LocationRoutesTest extends TestCase
         $response = $this->get("/api/locations/{$location->id}");
 
         $response->assertStatus(200);
-        $response->assertJson($location->toArray());
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'data' => $location->toArray(),
+        ]);
     }
 
     /** @test */
-    public function it_can_store_a_location() 
+    public function it_can_store_a_location()
     {
         $location = factory(Location::class)->make();
 
@@ -43,8 +61,16 @@ class LocationRoutesTest extends TestCase
         $storedLocation = (new Location())->first();
 
         $response->assertStatus(201);
-        $this->assertEquals($storedLocation->toArray(), $response->getData(true));
-        $response->assertJson($storedLocation->toArray());
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully created the record.',
+            'data' => $storedLocation->toArray(),
+        ]);
     }
 
     /** @test */
@@ -88,7 +114,16 @@ class LocationRoutesTest extends TestCase
         $storedLocation = (new Location())->first();
 
         $response->assertStatus(200);
-        $response->assertJson($updatedAttributes);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully updated the record.',
+            'data' => $updatedAttributes,
+        ]);
     }
 
     /** @test */
@@ -98,6 +133,15 @@ class LocationRoutesTest extends TestCase
 
         $response = $this->delete("/api/locations/{$location->id}");
         $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully deleted the record.',
+        ]);
 
         $this->assertDatabaseMissing((new Location())->getTable(), [ 'id' => $location->id ]);
     }

--- a/tests/Unit/Controllers/Auth/ForgotPasswordControllerTest.php
+++ b/tests/Unit/Controllers/Auth/ForgotPasswordControllerTest.php
@@ -41,10 +41,10 @@ class ForgotPasswordControllerTest extends TestCase
         $response = $controller->sendResetLinkEmail($request);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(
-            ['message' => 'A password reset email has been sent'],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'A password reset email has been sent',
+        ]);
     }
 
     /** @test */
@@ -75,9 +75,9 @@ class ForgotPasswordControllerTest extends TestCase
         $response = $controller->sendResetLinkEmail($request);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(
-            ['message' => 'A password reset email has been sent'],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'A password reset email has been sent',
+        ]);
     }
 }

--- a/tests/Unit/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Unit/Controllers/Auth/LoginControllerTest.php
@@ -26,9 +26,18 @@ class LoginControllerTest extends TestCase
         ]));
 
         $this->assertAuthenticated();
-        $this->assertArrayHasKey('access_token', $response->getData(true));
-        $this->assertArrayHasKey('token_type', $response->getData(true));
-        $this->assertArrayHasKey('expires_in', $response->getData(true));
+        
+        // Super gross looking assertions...
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully authenticated.',
+        ]);
+        $this->assertArrayHasKey('data', $response->getData(true));
+
+        $responseData = $response->getData(true)['data'];
+        $this->assertArrayHasKey('access_token', $responseData);
+        $this->assertArrayHasKey('token_type', $responseData);
+        $this->assertArrayHasKey('access_token', $responseData);
     }
 
     /** @test */
@@ -46,8 +55,10 @@ class LoginControllerTest extends TestCase
         ]));
         
         $this->assertEquals(401, $response->getStatusCode());
-        $this->assertArrayHasKey('error', $response->getData(true));
-        $this->assertEquals('Unauthorized', $response->getData()->error);
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Unauthorized.',
+        ]);
     }
 
     /** @test */

--- a/tests/Unit/Controllers/Auth/ResetPasswordControllerTest.php
+++ b/tests/Unit/Controllers/Auth/ResetPasswordControllerTest.php
@@ -45,10 +45,10 @@ class ResetPasswordControllerTest extends TestCase
         $response = $controller->reset($request);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(
-            ['message' => 'Password has successfully reset'],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Password has successfully reset.',
+        ]);
         Event::assertDispatched(PasswordChanged::class);
     }
 
@@ -86,9 +86,9 @@ class ResetPasswordControllerTest extends TestCase
         $response = $controller->reset($request);
 
         $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals(
-            ['message' => 'There was a problem resetting the password'],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'There was a problem resetting the password.',
+        ]);
     }
 }

--- a/tests/Unit/Controllers/Auth/VerificationControllerTest.php
+++ b/tests/Unit/Controllers/Auth/VerificationControllerTest.php
@@ -40,10 +40,10 @@ class VerificationControllerTest extends TestCase
         $response = $controller->verify($request);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(
-            [ 'message' => 'Email has been successfully verified' ],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Email has been successfully verified.',
+        ]);
     }
 
     /** @test */
@@ -68,7 +68,7 @@ class VerificationControllerTest extends TestCase
 
         $userService = $this->app->make(UserService::class);
         $controller = new VerificationController($userService);
-        $response = $controller->verify($request);
+        $controller->verify($request);
     }
 
     /** @test */
@@ -92,10 +92,10 @@ class VerificationControllerTest extends TestCase
         $response = $controller->verify($request);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(
-            [ 'message' => 'Email has already been verified' ],
-            $response->getData(true)
-        );
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Email has already been verified.',
+        ]);
     }
 
     /** @test */
@@ -142,9 +142,10 @@ class VerificationControllerTest extends TestCase
         $response = $controller->resend($req);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals([
-            'message' => 'Success',
-        ], $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Verification email has been sent.',
+        ]);
     }
 
     /** @test */
@@ -161,9 +162,10 @@ class VerificationControllerTest extends TestCase
         $response = $controller->resend($req);
 
         $this->assertEquals(403, $response->getStatusCode());
-        $this->assertEquals([
-            'error' => 'Email has already been verified',
-        ], $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Email has already been verified.',
+        ]);
     }
 
     /** @test */
@@ -173,6 +175,6 @@ class VerificationControllerTest extends TestCase
 
         $userService = $this->app->make(UserService::class);
         $controller = new VerificationController($userService);
-        $response = $controller->resend(new Request());
+        $controller->resend(new Request());
     }
 }

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -25,7 +25,11 @@ class LocationControllerTest extends TestCase
 
         $response = $locationController->index();
 
-        $this->assertCount(10, $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'data' => $locations->toArray(),
+        ]);
     }
 
     /** @test */
@@ -38,7 +42,11 @@ class LocationControllerTest extends TestCase
 
         $response = $locationController->show($location->id);
 
-        $this->assertEquals($location->toArray(), $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'data' => $location->toArray(),
+        ]);
     }
 
     /** @test */
@@ -58,7 +66,11 @@ class LocationControllerTest extends TestCase
 
         $record = (new Location())->first();
 
-        $this->assertEquals($record->toArray(), $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully created the record.',
+            'data' => $record->toArray(),
+        ]);
     }
 
     /** @test */
@@ -107,9 +119,11 @@ class LocationControllerTest extends TestCase
 
         $response = $locationController->update($request, $location->id);
 
-        $updatedLocation = (new Location())->first();
-
-        $this->assertEquals($attributes, $response->getData(true));
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully updated the record.',
+            'data' => $attributes,
+        ]);
     }
 
     /** @test */
@@ -120,7 +134,13 @@ class LocationControllerTest extends TestCase
         $locationService = $this->app->make(LocationService::class);
         $locationController = new LocationController($locationService);
 
-        $locationController->destroy($location->id);
+        $response = $locationController->destroy($location->id);
+
+        $this->assertContains($response->getData(true), [
+            'success' => true,
+            'message' => 'Successfully deleted the record.',
+            'data' => true,
+        ]);
 
         $this->assertDatabaseMissing((new Location())->getTable(), ['id' => $location->id]);
     }


### PR DESCRIPTION
This PR defines a standard under which a JSON response should be returned. Proposed standard is as follows:

```javascript
{
  "success": boolean,
  "message": string,
  "data": mixed
}
```

The `data` key is optional, while `success` and `message` are mandatory.

All current entities have ben updated to follow this standard. Unit tests have also been updated to reflect this as well.