### PR TITLE
Use singular enum naming convention

### DIFF
--- a/app/Enums/Amenity.php
+++ b/app/Enums/Amenity.php
@@ -5,17 +5,17 @@ namespace App\Enums;
 use MyCLabs\Enum\Enum;
 
 /**
- * @method static Amenities POTABLE_WATER()
- * @method static Amenities OVERNIGHT_PARKING()
- * @method static Amenities RESTROOMS()
- * @method static Amenities FAMILY_RESTROOM()
- * @method static Amenities DUMP_STATION()
- * @method static Amenities PET_AREA()
- * @method static Amenities VENDING()
- * @method static Amenities SECURITY()
- * @method static Amenities INDOOR_AREA()
+ * @method static Amenity POTABLE_WATER()
+ * @method static Amenity OVERNIGHT_PARKING()
+ * @method static Amenity RESTROOMS()
+ * @method static Amenity FAMILY_RESTROOM()
+ * @method static Amenity DUMP_STATION()
+ * @method static Amenity PET_AREA()
+ * @method static Amenity VENDING()
+ * @method static Amenity SECURITY()
+ * @method static Amenity INDOOR_AREA()
  */
-class Amenities extends Enum
+class Amenity extends Enum
 {
     private const POTABLE_WATER = 'potable_water';
     private const OVERNIGHT_PARKING = 'overnight_parking';

--- a/app/Enums/LocationType.php
+++ b/app/Enums/LocationType.php
@@ -5,11 +5,11 @@ namespace App\Enums;
 use MyCLabs\Enum\Enum;
 
 /**
- * @method static Amenities WELCOME_CENTER()
- * @method static Amenities REST_STOP()
- * @method static Amenities CAMPGROUND()
- * @method static Amenities PARKING_LOT()
- * @method static Amenities TRAVEL_CENTER()
+ * @method static LocationType WELCOME_CENTER()
+ * @method static LocationType REST_STOP()
+ * @method static LocationType CAMPGROUND()
+ * @method static LocationType PARKING_LOT()
+ * @method static LocationType TRAVEL_CENTER()
  */
 class LocationType extends Enum
 {

--- a/app/Http/Requests/CreateLocationFormRequest.php
+++ b/app/Http/Requests/CreateLocationFormRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Enums\Amenities;
+use App\Enums\Amenity;
 use App\Enums\LocationType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -45,7 +45,7 @@ class CreateLocationFormRequest extends FormRequest
             'amenities'                     => 'array',
             'amenities.*'                   => [
                 'string',
-                Rule::in(Amenities::toArray()),
+                Rule::in(Amenity::toArray()),
             ],
             'parking_duration'              => 'integer',
             'parking_spaces'                => 'array',

--- a/app/Http/Requests/UpdateLocationFormRequest.php
+++ b/app/Http/Requests/UpdateLocationFormRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Enums\Amenities;
+use App\Enums\Amenity;
 use App\Enums\LocationType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -45,7 +45,7 @@ class UpdateLocationFormRequest extends FormRequest
             'amenities'                     => 'array',
             'amenities.*'                   => [
                 'string',
-                Rule::in(Amenities::toArray()),
+                Rule::in(Amenity::toArray()),
             ],
             'parking_duration'              => 'integer',
             'parking_spaces'                => 'array',

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -2,14 +2,14 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use App\Enums\Amenities;
+use App\Enums\Amenity;
 use App\Enums\LocationType;
 use App\Models\Location;
 use Faker\Generator as Faker;
 
 $factory->define(Location::class, function (Faker $faker) {
     // A bit gross looking, but this will randomly assign amenities to the model.
-    $amenities = Amenities::toArray();
+    $amenities = Amenity::toArray();
     $numberOfSelectedAmenities = $faker->numberBetween(0, count($amenities));
     $selectedAmenities = [];
 

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Routes;
 
-use App\Enums\Amenities;
+use App\Enums\Amenity;
 use App\Enums\LocationType;
 use App\Models\Location;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -94,7 +94,7 @@ class LocationRoutesTest extends TestCase
             'status'            => 'Open',
             'condition'         => 'Fair',
             'amenities'         => [
-                (string) Amenities::OVERNIGHT_PARKING(),
+                (string) Amenity::OVERNIGHT_PARKING(),
             ],
             'parking_duration'  => 30,
             'parking_spaces'    => [

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit\Controllers;
 
 use App\Contracts\Services\LocationService;
-use App\Enums\Amenities;
+use App\Enums\Amenity;
 use App\Http\Controllers\LocationController;
 use App\Http\Requests\CreateLocationFormRequest;
 use App\Http\Requests\UpdateLocationFormRequest;
@@ -93,7 +93,7 @@ class LocationControllerTest extends TestCase
             'status'            => 'Open',
             'condition'         => 'Fair',
             'amenities'         => [
-                (string) Amenities::OVERNIGHT_PARKING(),
+                (string) Amenity::OVERNIGHT_PARKING(),
             ],
             'parking_duration'  => 30,
             'parking_spaces'    => [


### PR DESCRIPTION
Pretty self explanatory. Using singular naming convention rather than plural.