### PR TITLE
Add conditional check for exception status code

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -55,13 +55,35 @@ class Handler extends ExceptionHandler
             $request->headers->set('Accept', 'application/json');
         }
 
+        // dd(get_class($exception));
+
         if ($request->expectsJson()) {
             return new JsonResponse([
                 'success' => false,
                 'message' => $exception->getMessage(),
-            ], $exception->getStatusCode());
+            ], $this->getHttpStatusCode($exception));
         }
 
         return parent::render($request, $exception);
+    }
+
+    /**
+     * Parses the status code associated with the exception.
+     *
+     * @param  \Exception  $e
+     *
+     * @return int
+     */
+    protected function getHttpStatusCode(Exception $e): int
+    {
+        if (method_exists($e, 'getStatusCode')) {
+            $code = $e->getStatusCode();
+        } else if ($e->status && $e->status >= 100) {
+            $code = $e->status;
+        } else {
+            $code = 500;
+        }
+
+        return $code;
     }
 }


### PR DESCRIPTION
During testing it was revealed that exceptions do not follow a set standard for retrieving status codes. This will attempt to pull a status code from an exception using basic means, and fall back to a 500 server error if one cannot be obtained.