### PR TITLE
Get status code without editor complaining

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -78,7 +78,10 @@ class Handler extends ExceptionHandler
     protected function getHttpStatusCode(Exception $e): int
     {
         if (method_exists($e, 'getStatusCode')) {
-            $code = $e->getStatusCode();
+            $code = call_user_func([
+                $e,
+                'getStatusCode'
+            ]);
         } elseif ($e->status && $e->status >= 100) {
             $code = $e->status;
         } else {


### PR DESCRIPTION
This is just a refactor to keep my editor from screaming at me. Since the exception isn't type-hinted, Intelliphense for VSCode throws an error saying that the `getStatusCode` method does not exist. A check is being performed beforehand to make sure that the method does indeed exist, so including the method is fine. Refactoring this to execute the function differently takes care of editor complaints. while retaining functionality.