### PR TITLE
Implement Location Ratings

### DIFF
--- a/app/Contracts/Services/LocationService.php
+++ b/app/Contracts/Services/LocationService.php
@@ -18,29 +18,36 @@ interface LocationService
 
     /**
      * Fetches all records in a database table.
+     * Relationships can be loaded dynamically using parameters.
+     *
+     * @param  array  $relations
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function all(): Collection;
+    public function all(array $relations = []): Collection;
 
     /**
      * Finds and returns a record by its primary key.
+     * Relationships can be loaded dynamically using parameters.
      *
      * @param  string  $id
+     * @param  array   $relations
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function findOrFail(string $id): Model;
+    public function findOrFail(string $id, array $relations = []): Model;
 
     /**
      * Updates a record with the given attribute values.
+     * Relationships can be loaded dynamically using parameters.
      *
-     * @param  string  $id
+     * @param  string  $locationId
      * @param  array   $attributes
+     * @param  array   $relations
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function update(string $id, array $attributes): Model;
+    public function update(string $locationId, array $attributes, array $relations = []): Model;
 
     /**
      * Deletes a record from the system identified by its primary key.

--- a/app/Contracts/Services/RatingService.php
+++ b/app/Contracts/Services/RatingService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Contracts\Services;
+
+use App\Models\Rating;
+
+interface RatingService
+{
+    /**
+     * Updates an existing rating, creating a new entry if an existing record is not found.
+     *
+     * @param  string  $userId
+     * @param  string  $locationId
+     * @param  int     $rating
+     *
+     * @return \App\Models\Rating
+     */
+    public function updateOrCreate(string $userId, string $locationId, int $rating): Rating;
+}

--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Contracts\Services\LocationService;
 use App\Http\Requests\CreateLocationFormRequest;
 use App\Http\Requests\UpdateLocationFormRequest;
+use App\Http\Resources\Location as LocationResource;
+use App\Http\Resources\LocationCollection as LocationCollectionResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -20,7 +22,7 @@ class LocationController extends Controller
     /**
      * Create a new LocationController instance.
      *
-     * @param \App\Contracts\Services\LocationService $locationService
+     * @param  \App\Contracts\Services\LocationService  $locationService
      *
      * @return void
      */
@@ -39,7 +41,7 @@ class LocationController extends Controller
         return new JsonResponse([
             'success' => true,
             'message' => 'Successfully retrieved data.',
-            'data' => $this->locationService->all(),
+            'data' => new LocationCollectionResource($this->locationService->all(['ratings'])),
         ], 200);
     }
 
@@ -55,7 +57,9 @@ class LocationController extends Controller
         return new JsonResponse([
             'success' => true,
             'message' => 'Successfully created the record.',
-            'data' => $this->locationService->create($request->validated()),
+            'data' => new LocationResource(
+                $this->locationService->create($request->validated())
+            ),
         ], 201);
     }
 
@@ -71,7 +75,7 @@ class LocationController extends Controller
         return new JsonResponse([
             'success' => true,
             'message' => 'Successfully retrieved data.',
-            'data' => $this->locationService->findOrFail($locationId),
+            'data' => new LocationResource($this->locationService->findOrFail($locationId, ['ratings'])),
         ], 200);
     }
 
@@ -88,7 +92,9 @@ class LocationController extends Controller
         return new JsonResponse([
             'success' => true,
             'message' => 'Successfully updated the record.',
-            'data' => $this->locationService->update($locationId, $request->validated()),
+            'data' => new LocationResource(
+                $this->locationService->update($locationId, $request->validated())
+            ),
         ], 200);
     }
 

--- a/app/Http/Controllers/RatingController.php
+++ b/app/Http/Controllers/RatingController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Contracts\Services\LocationService;
+use App\Contracts\Services\RatingService;
+use App\Http\Requests\CreateRatingFormRequest;
+use App\Http\Resources\Rating as RatingResource;
+use App\Models\Rating;
+use Illuminate\Http\JsonResponse;
+
+class RatingController extends Controller
+{
+    /**
+     * Instance of the Location Service.
+     *
+     * @var \App\Contracts\Services\LocationService
+     */
+    protected $locationService;
+
+    /**
+     * Instance of the Rating Service.
+     *
+     * @var \App\Contracts\Services\RatingService
+     */
+    protected $ratingService;
+
+    /**
+     * Created a new RatingController instance.
+     *
+     * @param  \App\Contracts\Services\LocationService  $locationService
+     * @param  \App\Contracts\Services\RatingService    $ratingService
+     *
+     * @return void
+     */
+    public function __construct(LocationService $locationService, RatingService $ratingService)
+    {
+        $this->locationService = $locationService;
+        $this->ratingService = $ratingService;
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\CreateRatingFormRequest  $request
+     * @param  string                                      $locationId
+     *
+     * @return \Illuminate\Http\JsonResponse
+     *
+     * @todo extract the rating to a validation rule to make sure it stays between 1 and 5.
+     */
+    public function store(CreateRatingFormRequest $request, string $locationId): JsonResponse
+    {
+        try {
+            $location = $this->locationService->findOrFail($locationId);
+            $rating = $this->ratingService->updateOrCreate($request->user()->id, $location->id, $request->get('rating'));
+    
+            return new JsonResponse([
+                'success' => true,
+                'message' => 'Rating successful.',
+                'data' => new RatingResource($rating),
+            ], 200);
+        } catch (\Exception $e) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'There was a problem submitting the rating.',
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Requests/CreateRatingFormRequest.php
+++ b/app/Http/Requests/CreateRatingFormRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CreateRatingFormRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'rating' => [
+                'required',
+                'numeric',
+                'digits:1',
+                'between:1,5',
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/Location.php
+++ b/app/Http/Resources/Location.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Location extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * 
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'google_place_id' => $this->google_place_id,
+            'name' => $this->name,
+            'locale' => $this->locale,
+            'state' => $this->state,
+            'interstate' => $this->interstate,
+            'exit' => $this->exit,
+            'lat' => $this->lat,
+            'lng' => $this->lng,
+            'direction' => $this->direction,
+            'status' => $this->status,
+            'condition' => $this->condition,
+            'amenities' => $this->amenities,
+            'parking_duration' => $this->parking_duration,
+            'parking_spaces' => $this->parking_spaces,
+            'cell_service' => $this->cell_service,
+            'rating' => $this->whenLoaded('ratings', [
+                'avg' => $this->avgRating(),
+                'count' => $this->ratings()->count(),                
+            ]),
+        ];
+    }
+}

--- a/app/Http/Resources/LocationCollection.php
+++ b/app/Http/Resources/LocationCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class LocationCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * 
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return $this->collection->toArray();
+    }
+}

--- a/app/Http/Resources/Rating.php
+++ b/app/Http/Resources/Rating.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Rating extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     *
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'location_id' => $this->location_id,
+            'rating' => $this->rating,
+        ];
+    }
+}

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -4,12 +4,13 @@ namespace App\Models;
 
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Location extends Model
 {
     use Uuids;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string
@@ -85,6 +86,7 @@ class Location extends Model
      * @var array $hidden
      */
     protected $hidden = [
+        'ratings',
         'created_at',
         'updated_at',
         'deleted_at',
@@ -114,4 +116,24 @@ class Location extends Model
         'parking_spaces'    => 'array',
         'cell_service'      => 'array',
     ];
+
+    /**
+     * The Ratings that have been given for the location.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function ratings(): HasMany
+    {
+        return $this->hasMany(Rating::class, 'location_id', 'id');
+    }
+
+    /**
+     * Calculates the average rating associated with the Location.
+     *
+     * @return int
+     */
+    public function avgRating(): int
+    {
+        return $this->ratings()->avg('rating') ?: 0;
+    }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Model;
+
+class Rating extends Model
+{
+    use Uuids;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'ratings';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'location_id',
+        'rating',
+    ];
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'user_id',
+        'location_id',
+        'rating',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array $hidden
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array $casts
+     */
+    protected $casts = [
+        'id'            => 'string',
+        'user_id'       => 'string',
+        'location_id'   => 'string',
+        'rating'        => 'int',
+    ];
+}

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -28,6 +28,10 @@ class RepositoryServiceProvider extends ServiceProvider
             \App\Services\LocationService::class,
         );
         
+        $this->app->bind(
+            \App\Contracts\Services\RatingService::class,
+            \App\Services\RatingService::class,
+        );
     }
 
     /**

--- a/app/Services/LocationService.php
+++ b/app/Services/LocationService.php
@@ -20,7 +20,7 @@ class LocationService implements LocationServiceContract
      * Sets the model to be used throughout the instance.
      *
      * @param  \App\Models\Location  $location
-     * 
+     *
      * @return void
      */
     public function __construct(Location $location)
@@ -46,41 +46,60 @@ class LocationService implements LocationServiceContract
 
     /**
      * Fetches all records in a database table.
+     * Relationships can be loaded dynamically using parameters.
+     *
+     * @param  array  $relations
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function all(): Collection
+    public function all(array $relations = []): Collection
     {
         // If pagination is required, parameters can be passed to a paginate function to indicate how many records to
         // return for each query, while also indicating the page number (or offset)
         // in which to apply the context.
 
-        return $this->model->all();
+        $query = $this->model->newInstance();
+
+        if (! empty($relations) && count($relations) > 0) {
+            $query = $query->with($relations);
+        }
+
+        return $query->get();
     }
 
     /**
      * Finds and returns a record by its primary key.
+     * Relationships can be loaded dynamically using parameters.
      *
      * @param  string  $id
+     * @param  array   $relations
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function findOrFail(string $id): Model
+    public function findOrFail(string $id, array $relations = []): Model
     {
-        return $this->model->findOrFail($id);
+        $query = $this->model->newInstance();
+
+        if (! empty($relations) && count($relations) > 0) {
+            $query = $query->with($relations);
+        }
+
+        return $query->findOrFail($id);
     }
 
     /**
      * Updates a record with the given attribute values.
+     * Relationships can be loaded dynamically using parameters.
      *
      * @param  string  $locationId
      * @param  array   $attributes
+     * @param  array   $relations
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function update(string $locationId, array $attributes): Model
+    public function update(string $locationId, array $attributes, array $relations = []): Model
     {
-        $location = $this->findOrFail($locationId);
+        $location = $this->findOrFail($locationId, $relations);
 
         $location->fill($attributes)->save();
 

--- a/app/Services/RatingService.php
+++ b/app/Services/RatingService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\RatingService as ServicesRatingContract;
+use App\Models\Rating;
+
+class RatingService implements ServicesRatingContract
+{
+    /**
+     * The instance of the model to use used.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $model;
+
+    /**
+     * Sets the model to be used throughout the instance.
+     *
+     * @param  \App\Models\Rating  $rating
+     *
+     * @return void
+     */
+    public function __construct(Rating $rating)
+    {
+        $this->model = $rating;
+    }
+
+    /**
+     * Updates an existing rating, creating a new entry if an existing record is not found.
+     *
+     * @param  string  $userId
+     * @param  string  $locationId
+     * @param  int     $rating
+     *
+     * @return \App\Models\Rating
+     */
+    public function updateOrCreate(string $userId, string $locationId, int $rating): Rating
+    {
+        return $this->model->updateOrCreate([
+            'user_id' => $userId,
+            'location_id' => $locationId,
+        ], [
+            'rating' => $rating,
+        ]);
+    }
+}

--- a/database/factories/RatingFactory.php
+++ b/database/factories/RatingFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\Rating;
+use Faker\Generator as Faker;
+
+$factory->define(Rating::class, function (Faker $faker) {
+    return [
+        'user_id' => null,
+        'location_id' => null,
+        'rating' => $faker->numberBetween(1, 5),
+    ];
+});

--- a/database/migrations/2020_03_10_204023_create_ratings_table.php
+++ b/database/migrations/2020_03_10_204023_create_ratings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRatingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ratings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->uuid('location_id');
+            $table->integer('rating');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ratings');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,3 +28,6 @@ Route::resource('locations', 'LocationController')->only([
     'update',
     'destroy',
 ]);
+
+Route::post('/locations/{location_id}/ratings')->uses('RatingController@store')->name('locations.ratings.store')
+    ->middleware('auth');

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\Routes;
 use App\Enums\Amenity;
 use App\Enums\LocationType;
 use App\Models\Location;
+use App\Models\Rating;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -145,5 +147,49 @@ class LocationRoutesTest extends TestCase
         ]);
 
         $this->assertDatabaseMissing((new Location())->getTable(), [ 'id' => $location->id ]);
+    }
+
+    /** @test */
+    public function it_will_retrieve_the_average_rating_and_total_count_when_all_records_are_fetched()
+    {
+        $user = factory(User::class)->create();
+        $location = factory(Location::class)->create();
+        $rating = factory(Rating::class)->create([
+            'user_id' => $user->id,
+            'location_id' => $location->id,
+            'rating' => 3,
+        ]);
+
+        $response = $this->get('/api/locations');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'rating' => [
+                'avg' => 3,
+                'count' => 1,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_retrieve_the_average_rating_and_total_count_when_a_record_is_fetched()
+    {
+        $user = factory(User::class)->create();
+        $location = factory(Location::class)->create();
+        $rating = factory(Rating::class)->create([
+            'user_id' => $user->id,
+            'location_id' => $location->id,
+            'rating' => 3,
+        ]);
+
+        $response = $this->get("/api/locations/{$location->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'rating' => [
+                'avg' => 3,
+                'count' => 1,
+            ],
+        ]);
     }
 }

--- a/tests/Feature/Routes/RatingRoutesTest.php
+++ b/tests/Feature/Routes/RatingRoutesTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Feature\Routes;
+
+use App\Contracts\Services\AuthService;
+use App\Models\Location;
+use App\Models\Rating;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RatingRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Authenticates a user and returns the associated JWT.
+     *
+     * @param  \App\Models\User  $user
+     * @param  string            $passwordOverride
+     *
+     * @return string
+     */
+    public function getJWT(User $user, string $passwordOverride = null): string
+    {
+        $authService = $this->app->make(AuthService::class);
+        $token = $authService->attemptLoginWithCredentials([
+            'email' => $user->email,
+            'password' => $passwordOverride ?: 'password',
+        ]);
+
+        return $token['access_token'];
+    }
+
+    /** @test */
+    public function it_can_store_a_rating_for_a_given_location()
+    {
+        $user = factory(User::class)->create();
+        $location = factory(Location::class)->create();
+
+        $token = $this->getJWT($user);
+        
+        $response = $this->post("/api/locations/{$location->id}/ratings/", [
+            'rating' => 3,
+        ], [
+            'Authorization' => "Bearer {$token}",
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJsonStructure([
+            'id',
+            'user_id',
+            'location_id',
+            'rating',
+        ], $response->json()['data']);
+        $response->assertJsonFragment([
+            'success' => true,
+            'message' => 'Rating successful.',
+        ]);
+        $response->assertJsonFragment([
+            'user_id' => $user->id,
+            'location_id' => $location->id,
+            'rating' => 3,
+        ], $response->json()['data']);
+    }
+
+    /** @test */
+    public function it_can_update_an_existing_rating_for_a_given_location()
+    {
+        $user = factory(User::class)->create();
+        $location = factory(Location::class)->create();
+        $rating = factory(Rating::class)->create([
+            'user_id' => $user->id,
+            'location_id' => $location->id,
+            'rating' => 1,
+        ]);
+
+        $token = $this->getJWT($user);
+        
+        $response = $this->post("/api/locations/{$location->id}/ratings/", [
+            'rating' => 3,
+        ], [
+            'Authorization' => "Bearer {$token}",
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'data',
+        ]);
+        $response->assertJsonStructure([
+            'id',
+            'user_id',
+            'location_id',
+            'rating',
+        ], $response->json()['data']);
+        $response->assertJsonFragment([
+            'success' => true,
+            'message' => 'Rating successful.',
+        ]);
+        $response->assertJsonFragment([
+            'id' => $rating->id,
+            'user_id' => $user->id,
+            'location_id' => $location->id,
+            'rating' => 3,
+        ]);
+    }
+
+    /** @test */
+    public function only_an_authenticated_user_can_leave_a_rating()
+    {
+        $location = factory(Location::class)->create();
+        
+        $response = $this->post("/api/locations/{$location->id}/ratings/", [
+            'rating' => 3,
+        ]);
+
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
+        $response->assertJsonFragment([
+            'success' => false,
+            'message' => 'Token not provided',
+        ]);
+    }
+
+    /** @test */
+    public function it_will_return_an_error_if_the_location_does_not_exist()
+    {
+        $user = factory(User::class)->create();
+
+        $token = $this->getJWT($user);
+        
+        $response = $this->post("/api/locations/some-invalid-id/ratings/", [
+            'rating' => 3,
+        ], [
+            'Authorization' => "Bearer {$token}",
+        ]);
+
+        $response->assertStatus(500);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+        ]);
+        $response->assertJsonFragment([
+            'success' => false,
+            'message' => 'There was a problem submitting the rating.',
+        ]);
+    }
+
+    /** @test */
+    public function it_validates_the_rating_field()
+    {
+        $user = factory(User::class)->create();
+        $location = factory(Location::class)->create();
+
+        $token = $this->getJWT($user);
+        
+        $response = $this->post(
+            "/api/locations/{$location->id}/ratings/",
+            [],
+            ['Authorization' => "Bearer {$token}",]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'errors',
+        ]);
+        $response->assertJson([
+            'success' => false,
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'rating' => [
+                    'The rating field is required.',
+                ],
+            ],
+        ]);
+
+        $response = $this->post(
+            "/api/locations/{$location->id}/ratings/",
+            ['rating' => 'string'],
+            ['Authorization' => "Bearer {$token}"]
+        );
+
+        $response->assertJson([
+            'success' => false,
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'rating' => [
+                    'The rating must be a number.',
+                    'The rating must be 1 digits.',
+                    'The rating must be between 1 and 5.',
+                ],
+            ],
+        ]);
+
+        $response = $this->post(
+            "/api/locations/{$location->id}/ratings/",
+            ['rating' => 1.5],
+            ['Authorization' => "Bearer {$token}"]
+        );
+
+        $response->assertJson([
+            'success' => false,
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'rating' => [
+                    'The rating must be 1 digits.',
+                ],
+            ],
+        ]);
+
+        $response = $this->post(
+            "/api/locations/{$location->id}/ratings/",
+            ['rating' => 6],
+            ['Authorization' => "Bearer {$token}"]
+        );
+
+        $response->assertJson([
+            'success' => false,
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'rating' => [
+                    'The rating must be between 1 and 5.',
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Models/LocationTest.php
+++ b/tests/Unit/Models/LocationTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Location;
+use App\Models\Rating;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Tests\TestCase;
 
 class LocationTest extends TestCase
@@ -85,6 +87,7 @@ class LocationTest extends TestCase
         $location = new Location();
 
         $hiddenFields = [
+            'ratings',
             'created_at',
             'updated_at',
             'deleted_at',
@@ -121,5 +124,14 @@ class LocationTest extends TestCase
         ];
 
         $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_has_ratings()
+    {
+        $location = new Location();
+
+        $this->assertInstanceOf(HasMany::class, $location->ratings());
+        $this->assertInstanceOf(Rating::class, $location->ratings()->getRelated());
     }
 }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Rating;
+use Tests\TestCase;
+
+class RatingTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $rating = new Rating();
+
+        $this->assertEquals('ratings', $rating->getTable());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $rating = new Rating();
+
+        $this->assertEquals('string', $rating->getKeyType());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_properties_to_be_assigned_in_mass()
+    {
+        $rating = new Rating();
+
+        $expected = [
+            'user_id',
+            'location_id',
+            'rating',
+        ];
+
+        $this->assertEquals($expected, $rating->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $rating = new Rating();
+
+        $visibleFields = [
+            'id',
+            'user_id',
+            'location_id',
+            'rating',
+        ];
+
+        $this->assertEquals($visibleFields, $rating->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $rating = new Rating();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($hiddenFields, $rating->getHidden());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_return_type_for_each_field()
+    {
+        $rating = new Rating();
+
+        $fields = $rating->getCasts();
+
+        $expected = [
+            'id'            => 'string',
+            'user_id'       => 'string',
+            'location_id'   => 'string',
+            'rating'        => 'int',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+}


### PR DESCRIPTION
This PR implements Ratings for the Location entity. Ratings are simply composed of a `user_id`, `location_id`, and a `rating`. The only option for interacting with the Ratings entity directly through the API is by creating/updating the record (done via the same route). Every other interaction should be done through the Location entity.

When querying a Location, the result will automatically append the average rating, along with a count of the total number of ratings present for a given Location. To support this, the Location Service was refactored to support the dynamic loading of relations. This is to prevent the Location Service from loading the Ratings in the event they are not needed. 

JSON Resources have also been created for the Location entity. This will ensure a standard structure when returning a resource through the API. It will also ensure that the Rating information is appended to the record **only when the relation is loaded** in order to prevent the N+1 query issue if the relation was not loaded when querying the records.

Rating controller tests have been excluded from this PR as directly testing the controller is starting to seem redundant. Integration tests via the public API should be sufficient enough to test all of the related functionality without all of the overhead that comes with mocking requirements and injecting them into a controller. Other controller tests will likely be removed in the future.

As a basic overview of the additions:
* Rating scaffolding has been added
* Refactored Location Service to support dynamic relation loading
* Location Resources has been added
* Rating information will only be present on a Location response if the Rating relation is loaded
* Unit testing controllers will no longer be performed