### PR TITLE
Refactor exception handler to support validation errors

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -59,10 +59,16 @@ class Handler extends ExceptionHandler
         }
 
         if ($request->expectsJson()) {
-            return new JsonResponse([
+            $response = [
                 'success' => false,
                 'message' => $exception->getMessage(),
-            ], $this->getHttpStatusCode($exception));
+            ];
+
+            if (method_exists($exception, 'errors')) {
+                $response['errors'] = call_user_func([$exception, 'errors']);
+            }
+
+            return new JsonResponse($response, $this->getHttpStatusCode($exception));
         }
 
         return parent::render($request, $exception);
@@ -82,7 +88,7 @@ class Handler extends ExceptionHandler
                 $e,
                 'getStatusCode'
             ]);
-        } elseif ($e->status && $e->status >= 100) {
+        } elseif (property_exists($e, 'status') && $e->status >= 100) {
             $code = $e->status;
         } else {
             $code = 500;


### PR DESCRIPTION
When testing validation rules, the individual messages were not being returned to the user. This PR refactors the exception handler to check for these messages, and then append them to the response.